### PR TITLE
Sasha/tunnel fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ delayed_racktest:
 virttest:
 	RACKATTACK_PROVIDER=tcp://localhost:1014@@amqp://guest:guest@localhost:1013/%2F@@http://localhost:1016 $(MAKE) delayed_racktest
 phystest:
-	RACKATTACK_PROVIDER=tcp://rackattack-provider:1014@@amqp://guest:guest@rackattack-provider:1013/%2F@@http://rackattack-provider:1016 $(MAKE) delayed_racktest
+	RACKATTACK_PROVIDER=tcp://rackattack-provider.dc1.strato:1014@@amqp://guest:guest@rackattack-provider.dc1.strato:1013/%2F@@http://rackattack-provider.dc1.strato:1016 $(MAKE) delayed_racktest

--- a/py/rackattack/ssh/tunnelconnection.py
+++ b/py/rackattack/ssh/tunnelconnection.py
@@ -55,7 +55,12 @@ class TunnelConnection:
             assert self._channel not in readReadySockets
             return
         if self._channel in readReadySockets:
-            data = self._channel.recv(2048)
+            try:
+                data = self._channel.recv(2048)
+            except socket.error as e:
+                self._shutdownFromRemote = True
+                return
+
             if len(data) != 0:
                 try:
                     self._socket.send(data)
@@ -90,7 +95,10 @@ class TunnelConnection:
                     self._logger.debug("Both ends shutdown, closing connection")
                     self.close()
             else:
-                self._channel.send(data)
+                try:
+                    self._channel.send(data)
+                except socket.error as e:
+                    self._shutdownFromRemote = True
 
     def _safeShutdown(self, thing, shutdownFlag):
         try:


### PR DESCRIPTION
bugfix: when other end of the tunnel is closed during tunnel operation tunnel proxy brakes
    
What happens is that if exception is thrown during read from the remote endpoint (for example when remote application exits), exceptions are not caught by the tunnel and tunnel thread collapses. this prevents from operating other tunels or opening new tunels.