### PR TITLE
connect to existing allocation

### DIFF
--- a/py/rackattack/tcp/client.py
+++ b/py/rackattack/tcp/client.py
@@ -6,9 +6,12 @@ from rackattack.tcp import subscribe
 from rackattack.tcp import suicide
 from rackattack.tcp import transport
 import urllib2
+import os
+import logging
 
 
 class Client(api.Client):
+
     def __init__(self,
                  providerRequestLocation,
                  providerSubscribeLocation,
@@ -31,6 +34,12 @@ class Client(api.Client):
             cmd='allocate',
             requirements=jsonableRequirements,
             allocationInfo=allocationInfo.__dict__)
+        return self.getAllocationInstance(requirements, allocationID)
+
+    def allocateExisting(self, requirements, allocationID):
+        return self.getAllocationInstance(requirements, allocationID)
+
+    def getAllocationInstance(self, requirements, allocationID):
         allocationInstance = allocation.Allocation(
             id=allocationID, requirements=requirements, ipcClient=self,
             subscribe=self._subscribe, heartbeat=self._heartbeat)


### PR DESCRIPTION
py/rackattack/tcp/client.py - added feature to enable connection to an existing allocation by passing an allocation ID. Separate allocate into two methods: allocate and getAllocationInstance. Use allocateExisting instead of allocate to connect to existing allocation

@rom-stratoscale @eliran-stratoscale @michaelk-stratoscale @mickey-stratoscale @igal-stratoscale @sergey-stratoscale 